### PR TITLE
이미지의 순서를 보장하고 이미지 줌 뷰에서의 사용성을 개선했습니다.

### DIFF
--- a/OwnMyWay/OwnMyWay/Extension/UIView+.swift
+++ b/OwnMyWay/OwnMyWay/Extension/UIView+.swift
@@ -77,3 +77,13 @@ extension UIView {
         self.layoutIfNeeded()
     }
 }
+
+extension UIView {
+    var firstResponder: UIView? {
+        guard !self.isFirstResponder else { return self }
+        for subview in subviews {
+            if let firstResponder = subview.firstResponder { return firstResponder }
+        }
+        return nil
+    }
+}

--- a/OwnMyWay/OwnMyWay/Storyboard/DetailImage.storyboard
+++ b/OwnMyWay/OwnMyWay/Storyboard/DetailImage.storyboard
@@ -5,7 +5,6 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Image references" minToolsVersion="12.0"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,11 +16,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="loZ-PL-P0K">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="loZ-PL-P0K">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mzs-rH-k0t">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -35,7 +34,7 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="bLf-A9-D8B"/>
                             </scrollView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xp6-fO-cZ3">
-                                <rect key="frame" x="350" y="64" width="44" height="44"/>
+                                <rect key="frame" x="350" y="60" width="44" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="44" id="IHx-Ut-P8N"/>
                                     <constraint firstAttribute="height" constant="44" id="wa0-j7-8hH"/>
@@ -52,21 +51,20 @@
                                 </connections>
                             </button>
                             <pageControl opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="R5J-Af-tuI">
-                                <rect key="frame" x="129" y="816" width="156" height="26"/>
+                                <rect key="frame" x="129" y="850" width="156" height="26"/>
                             </pageControl>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstItem="loZ-PL-P0K" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="3Rr-Zg-kUy"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="Xp6-fO-cZ3" secondAttribute="trailing" constant="20" id="A00-sZ-d1L"/>
-                            <constraint firstItem="loZ-PL-P0K" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Zeh-R1-rCi"/>
-                            <constraint firstItem="R5J-Af-tuI" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" constant="-20" id="fnL-Qy-XC4"/>
-                            <constraint firstItem="loZ-PL-P0K" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="hXm-n2-JWK"/>
-                            <constraint firstItem="R5J-Af-tuI" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="j1G-CV-LGe"/>
-                            <constraint firstItem="loZ-PL-P0K" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="n6e-Qp-pA2"/>
-                            <constraint firstItem="Xp6-fO-cZ3" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="20" id="xes-JL-icm"/>
+                            <constraint firstItem="loZ-PL-P0K" firstAttribute="trailing" secondItem="5EZ-qb-Rvc" secondAttribute="trailing" id="3Rr-Zg-kUy"/>
+                            <constraint firstAttribute="trailing" secondItem="Xp6-fO-cZ3" secondAttribute="trailing" constant="20" id="A00-sZ-d1L"/>
+                            <constraint firstItem="loZ-PL-P0K" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="Zeh-R1-rCi"/>
+                            <constraint firstItem="R5J-Af-tuI" firstAttribute="bottom" secondItem="5EZ-qb-Rvc" secondAttribute="bottom" constant="-20" id="fnL-Qy-XC4"/>
+                            <constraint firstItem="loZ-PL-P0K" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" id="hXm-n2-JWK"/>
+                            <constraint firstItem="R5J-Af-tuI" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="j1G-CV-LGe"/>
+                            <constraint firstItem="loZ-PL-P0K" firstAttribute="bottom" secondItem="5EZ-qb-Rvc" secondAttribute="bottom" id="n6e-Qp-pA2"/>
+                            <constraint firstItem="Xp6-fO-cZ3" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" constant="60" id="xes-JL-icm"/>
                         </constraints>
                     </view>
                     <connections>

--- a/OwnMyWay/OwnMyWay/View/LandmarkAnnotationView.swift
+++ b/OwnMyWay/OwnMyWay/View/LandmarkAnnotationView.swift
@@ -39,7 +39,7 @@ final class LandmarkAnnotationView: MKAnnotationView {
         let detailView = UIView()
         let imageView = UIImageView(frame: rect)
         detailView.translatesAutoresizingMaskIntoConstraints = false
-        let _ = imageView.setNetworkImage(with: annotation.image)
+        _ = imageView.setNetworkImage(with: annotation.image)
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         detailView.addSubview(imageView)

--- a/OwnMyWay/OwnMyWay/ViewController/AddRecordViewController.swift
+++ b/OwnMyWay/OwnMyWay/ViewController/AddRecordViewController.swift
@@ -317,7 +317,7 @@ extension AddRecordViewController: PHPickerViewControllerDelegate {
                 longitude: coordinate?.longitude.magnitude
             )
         }
-        self.viewModel?.allocImages(size: results.count)
+        self.viewModel?.allocateImages(size: results.count)
         results.enumerated().forEach { [weak self] index, result in
             result.itemProvider.loadFileRepresentation(
                 forTypeIdentifier: UTType.image.identifier
@@ -388,7 +388,7 @@ extension AddRecordViewController: UIImagePickerControllerDelegate,
                 )
             }
         }
-        self.viewModel?.allocImages(size: 1)
+        self.viewModel?.allocateImages(size: 1)
         if let imageURL = info[UIImagePickerController.InfoKey.imageURL] as? URL {
             self.viewModel?.didEnterPhotoURL(with: imageURL, at: 0)
         }

--- a/OwnMyWay/OwnMyWay/ViewController/AddRecordViewController.swift
+++ b/OwnMyWay/OwnMyWay/ViewController/AddRecordViewController.swift
@@ -9,19 +9,6 @@ import Combine
 import UIKit
 import PhotosUI
 
-@available(iOS 14.0, *)
-let supportedPhotoExtensions = [
-    UTType.rawImage.identifier,
-    UTType.tiff.identifier,
-    UTType.bmp.identifier,
-    UTType.png.identifier,
-    UTType.heif.identifier,
-    UTType.heic.identifier,
-    UTType.jpeg.identifier,
-    UTType.webP.identifier,
-    UTType.gif.identifier
-]
-
 enum TransitionType {
     case cancel, submit
 }
@@ -167,14 +154,12 @@ extension AddRecordViewController {
     }
 
     private func configureNotifications() {
-        NotificationCenter.default.addObserver(
-            self,
+        NotificationCenter.default.addObserver( self,
             selector: #selector(keyboardWillShowAction(_:)),
             name: UIResponder.keyboardWillShowNotification,
             object: nil
         )
-        NotificationCenter.default.addObserver(
-            self,
+        NotificationCenter.default.addObserver( self,
             selector: #selector(keyboardWillHideAction(_:)),
             name: UIResponder.keyboardWillHideNotification,
             object: nil
@@ -291,10 +276,8 @@ extension AddRecordViewController: PHPickerViewControllerDelegate {
                     }
 
                     let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-
                     alert.addAction(moveAction)
                     alert.addAction(cancelAction)
-
                     self?.present(alert, animated: true)
                 default:
                     var config = PHPickerConfiguration(photoLibrary: PHPhotoLibrary.shared())
@@ -334,22 +317,13 @@ extension AddRecordViewController: PHPickerViewControllerDelegate {
                 longitude: coordinate?.longitude.magnitude
             )
         }
-
-        results.forEach { [weak self] result in
-            for type in supportedPhotoExtensions {
-                if result.itemProvider.hasRepresentationConforming(
-                    toTypeIdentifier: type,
-                    fileOptions: .init()
-                ) {
-                    result.itemProvider.loadFileRepresentation(
-                        forTypeIdentifier: type
-                    ) { url, error in
-                        guard error == nil,
-                              let url = url else { return }
-                        self?.viewModel?.didEnterPhotoURL(with: url)
-                    }
-                    break
-                }
+        self.viewModel?.allocImages(size: results.count)
+        results.enumerated().forEach { [weak self] index, result in
+            result.itemProvider.loadFileRepresentation(
+                forTypeIdentifier: UTType.image.identifier
+            ) { url, error in
+                guard error == nil, let url = url else { return }
+                self?.viewModel?.didEnterPhotoURL(with: url, at: results.count - index)
             }
         }
         self.dismiss(animated: true, completion: nil)
@@ -414,20 +388,11 @@ extension AddRecordViewController: UIImagePickerControllerDelegate,
                 )
             }
         }
+        self.viewModel?.allocImages(size: 1)
         if let imageURL = info[UIImagePickerController.InfoKey.imageURL] as? URL {
-            self.viewModel?.didEnterPhotoURL(with: imageURL)
+            self.viewModel?.didEnterPhotoURL(with: imageURL, at: 0)
         }
         picker.dismiss(animated: true)
     }
 }
 
-// MARK: - fileprivate extension for UIView
-fileprivate extension UIView {
-    var firstResponder: UIView? {
-        guard !self.isFirstResponder else { return self }
-        for subview in subviews {
-            if let firstResponder = subview.firstResponder { return firstResponder }
-        }
-        return nil
-    }
-}

--- a/OwnMyWay/OwnMyWay/ViewController/DetailImageViewController.swift
+++ b/OwnMyWay/OwnMyWay/ViewController/DetailImageViewController.swift
@@ -102,6 +102,25 @@ extension DetailImageViewController: UIScrollViewDelegate {
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
         self.backButton.isHidden = true
         self.pageControl.isHidden = true
+        if scrollView.zoomScale > 0.1 {
+            if  let imageView = scrollView.subviews.first as? UIImageView,
+                let image = imageView.image {
+                let ratioW = imageView.frame.width / image.size.width
+                let ratioH = imageView.frame.height / image.size.height
+                let ratio = ratioW < ratioH ? ratioW:ratioH
+                let newWidth = image.size.width * ratio
+                let newHeight = image.size.height * ratio
+                let leftInset = (newWidth * scrollView.zoomScale > imageView.frame.width ?
+                           newWidth - imageView.frame.width :
+                           scrollView.frame.width - scrollView.contentSize.width) / 2
+                let topInset = (newHeight * scrollView.zoomScale > imageView.frame.height ?
+                          newHeight - imageView.frame.height :
+                          scrollView.frame.height - scrollView.contentSize.height) / 2
+                scrollView.contentInset = UIEdgeInsets(
+                    top: topInset, left: leftInset, bottom: topInset, right: leftInset
+                )
+            }
+        }
     }
 
     func scrollViewDidEndZooming(

--- a/OwnMyWay/OwnMyWay/ViewController/DetailImageViewController.swift
+++ b/OwnMyWay/OwnMyWay/ViewController/DetailImageViewController.swift
@@ -105,9 +105,9 @@ extension DetailImageViewController: UIScrollViewDelegate {
         if scrollView.zoomScale > 0.1 {
             if  let imageView = scrollView.subviews.first as? UIImageView,
                 let image = imageView.image {
-                let ratioW = imageView.frame.width / image.size.width
-                let ratioH = imageView.frame.height / image.size.height
-                let ratio = ratioW < ratioH ? ratioW:ratioH
+                let ratioWidth = imageView.frame.width / image.size.width
+                let ratioHeight = imageView.frame.height / image.size.height
+                let ratio = ratioWidth < ratioHeight ? ratioWidth:ratioHeight
                 let newWidth = image.size.width * ratio
                 let newHeight = image.size.height * ratio
                 let leftInset = (newWidth * scrollView.zoomScale > imageView.frame.width ?

--- a/OwnMyWay/OwnMyWay/ViewModel/AddRecordViewModel.swift
+++ b/OwnMyWay/OwnMyWay/ViewModel/AddRecordViewModel.swift
@@ -23,7 +23,8 @@ protocol AddRecordViewModel {
     func didEnterTime(with date: Date?)
     func didEnterCoordinate(latitude: Double?, longitude: Double?)
     func didEnterContent(with text: String?)
-    func didEnterPhotoURL(with url: URL)
+    func allocImages(size: Int)
+    func didEnterPhotoURL(with url: URL, at indexFromBack: Int)
     func didRemovePhoto(at index: Int)
     func didTouchSubmitButton()
     func didTouchLocationButton()
@@ -133,13 +134,18 @@ final class DefaultAddRecordViewModel: AddRecordViewModel {
         self.record.content = text
     }
 
-    func didEnterPhotoURL(with url: URL) {
-        self.record.photoIDs?.append(url.path)
-        let index = (record.photoIDs?.count ?? 0) - 1
+    func allocImages(size: Int) {
+        self.record.photoIDs?.append(contentsOf: [String].init(repeating: "", count: size))
+    }
+
+    func didEnterPhotoURL(with url: URL, at indexFromBack: Int) {
+        guard let count = self.record.photoIDs?.count else { return }
+        let indexFromFront = count - indexFromBack
+        
         self.usecase.executePickingPhoto(with: url) { [weak self] result in
             switch result {
             case .success(let copiedURL):
-                self?.record.photoIDs?[index] = copiedURL
+                self?.record.photoIDs?[indexFromFront] = copiedURL
                 self?.tempPhotoIDs.append(copiedURL)
                 self?.isValidPhotos = true
             case .failure(let error):

--- a/OwnMyWay/OwnMyWay/ViewModel/AddRecordViewModel.swift
+++ b/OwnMyWay/OwnMyWay/ViewModel/AddRecordViewModel.swift
@@ -23,7 +23,7 @@ protocol AddRecordViewModel {
     func didEnterTime(with date: Date?)
     func didEnterCoordinate(latitude: Double?, longitude: Double?)
     func didEnterContent(with text: String?)
-    func allocImages(size: Int)
+    func allocateImages(size: Int)
     func didEnterPhotoURL(with url: URL, at indexFromBack: Int)
     func didRemovePhoto(at index: Int)
     func didTouchSubmitButton()
@@ -134,14 +134,14 @@ final class DefaultAddRecordViewModel: AddRecordViewModel {
         self.record.content = text
     }
 
-    func allocImages(size: Int) {
+    func allocateImages(size: Int) {
         self.record.photoIDs?.append(contentsOf: [String].init(repeating: "", count: size))
     }
 
     func didEnterPhotoURL(with url: URL, at indexFromBack: Int) {
         guard let count = self.record.photoIDs?.count else { return }
         let indexFromFront = count - indexFromBack
-        
+
         self.usecase.executePickingPhoto(with: url) { [weak self] result in
             switch result {
             case .success(let copiedURL):


### PR DESCRIPTION
### Task 🔨
- [x] 이미지 순서대로 들어오도록 개선
- [x] 이미지 줌 뷰에서 검정색 영역 확대 안되도록 개선
- [x] 이미지 줌 뷰 safe area가 아니라 찐 풀스크린이 되도록 개선

### 체크리스트 ✅

- [x] Merge하는 브랜치 확인
- [x] 코드컨벤션 준수
- [x] 커밋컨벤션 준수
- [x] 커밋 세분화
- [ ] 코드를 검증하는 테스트 추가
- [ ] 관련된 기존 테스트 통과여부 확인
- [x] 리뷰어와 Label을 올바르게 설정

### 도큐먼트 📖
- [이미지 줌 뷰 코드 참고](https://velog.io/@kirri1124/%EC%82%AC%EC%A7%84-%EB%B7%B0%EC%96%B4-%EC%95%B1%EC%9D%84-%EB%A7%8C%EB%93%A4%EC%96%B4%EB%B4%A4%EB%8B%A4)
