### PR TITLE
13 버전에서 캘린더 다크모드 표시 못하던 문제와 가로모드를 잠궜습니다.

### DIFF
--- a/OwnMyWay/OwnMyWay/AppDelegate.swift
+++ b/OwnMyWay/OwnMyWay/AppDelegate.swift
@@ -16,6 +16,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ContextAccessable {
         return true
     }
 
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return .portrait
+    }
+
     // MARK: UISceneSession Lifecycle
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {

--- a/OwnMyWay/OwnMyWay/Info.plist
+++ b/OwnMyWay/OwnMyWay/Info.plist
@@ -26,6 +26,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>location</string>

--- a/OwnMyWay/OwnMyWay/View/OMWCalendar.swift
+++ b/OwnMyWay/OwnMyWay/View/OMWCalendar.swift
@@ -111,6 +111,7 @@ class OMWCalendar: UIView {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.allowsMultipleSelection = false
         collectionView.dataSource = self.previousDataSource
+        collectionView.backgroundColor = .clear
         self.configure(collectionView: collectionView)
         return collectionView
     }()
@@ -125,6 +126,7 @@ class OMWCalendar: UIView {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.allowsMultipleSelection = false
         collectionView.dataSource = self.currentDataSource
+        collectionView.backgroundColor = .clear
         self.configure(collectionView: collectionView)
         return collectionView
     }()
@@ -139,6 +141,7 @@ class OMWCalendar: UIView {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.allowsMultipleSelection = false
         collectionView.dataSource = self.nextDataSource
+        collectionView.backgroundColor = .clear
         self.configure(collectionView: collectionView)
         return collectionView
     }()


### PR DESCRIPTION
### Task 🔨
- 13버전에서 캘린더 다크모드 표시 못하던 문제 해결
- 가로모드 잠금

### 체크리스트 ✅

- [x] Merge하는 브랜치 확인
- [x] 코드컨벤션 준수
- [x] 커밋컨벤션 준수
- [x] 커밋 세분화
- [ ] 코드를 검증하는 테스트 추가
- [ ] 관련된 기존 테스트 통과여부 확인
- [x] 리뷰어와 Label을 올바르게 설정